### PR TITLE
Don't add the default difficulty to song metadata

### DIFF
--- a/source/funkin/ui/debug/charting/ChartEditorState.hx
+++ b/source/funkin/ui/debug/charting/ChartEditorState.hx
@@ -1362,7 +1362,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
       result = [];
       trace('Initializing blank chart for difficulty ' + selectedDifficulty);
       currentSongChartData.notes.set(selectedDifficulty, result);
-      currentSongMetadata.playData.difficulties.pushUnique(selectedDifficulty);
       return result;
     }
     return result;
@@ -1371,7 +1370,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
   function set_currentSongChartNoteData(value:Array<SongNoteData>):Array<SongNoteData>
   {
     currentSongChartData.notes.set(selectedDifficulty, value);
-    currentSongMetadata.playData.difficulties.pushUnique(selectedDifficulty);
     return value;
   }
 
@@ -1662,9 +1660,6 @@ class ChartEditorState extends UIState // UIState derives from MusicBeatState
     notePreviewDirty = true;
     noteTooltipsDirty = true;
     notePreviewViewportBoundsDirty = true;
-
-    // Make sure the difficulty we selected is in the list of difficulties.
-    currentSongMetadata.playData.difficulties.pushUnique(selectedDifficulty);
 
     return selectedDifficulty;
   }

--- a/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
+++ b/source/funkin/ui/debug/charting/handlers/ChartEditorImportExportHandler.hx
@@ -119,6 +119,7 @@ class ChartEditorImportExportHandler
   {
     state.songMetadata = newSongMetadata;
     state.songChartData = newSongChartData;
+    state.selectedDifficulty = state.availableDifficulties[0];
 
     Conductor.instance.forceBPM(null); // Disable the forced BPM.
     Conductor.instance.instrumentalOffset = state.currentInstrumentalOffset; // Loads from the metadata.
@@ -372,6 +373,12 @@ class ChartEditorImportExportHandler
     var zipEntries:Array<haxe.zip.Entry> = [];
 
     var variations = state.availableVariations;
+
+    if (state.currentSongMetadata.playData.difficulties.pushUnique(state.selectedDifficulty))
+    {
+      // Just in case the user deleted all or didn't add a difficulty
+      state.difficultySelectDirty = true;
+    }
 
     for (variation in variations)
     {


### PR DESCRIPTION
It'll now only add the current difficulty to the metadata if it doesn't exist in it when saved.

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.

## Include any relevant screenshots or videos.
